### PR TITLE
Dep/nextjs sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,12 @@
-
 ###start
 # These are added during the post install and then the gitignore rules removed
-.zesty
-next.config.js
-./next.config.js
+zesty.config.json
 views/zesty
 */views/zesty
 ###end
 
-package-lock.json
+# zesty.io cache
+.zesty
 
 # Logs
 logs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
-  "name": "nextjs-marketing",
+  "name": "nextjs-v13-starter",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "nextjs-marketing",
+      "name": "nextjs-v13-starter",
       "version": "1.0.0",
-      "hasInstallScript": true,
       "dependencies": {
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nextjs-marketing",
+  "name": "nextjs-v13-starter",
   "author": "Zesty.io Platform Inc.",
   "version": "1.0.0",
   "private": true,
@@ -7,13 +7,14 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "sync": "npx @zesty-io/nextjs-sync",
     "precommit": "pretty-quick --staged",
-    "postinstall": "zesty init && npm run sync",
+    "postinstall": "npm run init",
     "lint": "next lint",
     "type-check": "tsc --noEmit",
     "visualTest": "npx lost-pixel",
-    "updateBaselines": "npx lost-pixel update"
+    "updateBaselines": "npx lost-pixel update",
+    "sync": "npx nextjs-sync",
+    "init": "zesty init && npx nextjs-sync-create-settings && npx nextjs-sync-create-config && npx nextjs-sync"
   },
   "dependencies": {
     "@emotion/react": "^11.9.0",


### PR DESCRIPTION
Switch to the latest nextjs-sync which now uses a `zesty.config.json` file versus the previous `.env` file